### PR TITLE
[Fix] 설정 화면 모달 동작 오류 수정 및 UX 개선

### DIFF
--- a/src/components/settings/ProfileCard.vue
+++ b/src/components/settings/ProfileCard.vue
@@ -23,7 +23,7 @@
         @change="handleFileUpload"
       />
 
-      <button class="camera-btn">
+      <button class="camera-btn" @click="triggerUpload">
         <svg
           width="20"
           height="20"
@@ -52,8 +52,12 @@
     <p class="email-text">{{ user.email }}</p>
     <button class="edit-profile-btn" @click="openEditModal">프로필 수정</button>
 
-    <div v-if="isModalOpen" class="modal-overlay" @click="closeEditModal">
-      <div class="modal-content" @click.stop>
+    <div
+      v-if="isModalOpen"
+      class="modal-overlay"
+      @mousedown.self="closeEditModal"
+    >
+      <div class="modal-content">
         <div class="modal-header">
           <h3>프로필 수정</h3>
           <button class="close-icon-btn" @click="closeEditModal">✕</button>
@@ -86,7 +90,7 @@
 
 <script setup>
 // import { defineProps } from 'vue';
-import { ref, reactive } from 'vue';
+import { ref, reactive, onUnmounted } from 'vue';
 
 const props = defineProps({
   user: {
@@ -118,15 +122,25 @@ const handleFileUpload = (event) => {
 const isModalOpen = ref(false);
 const editForm = reactive({ nickname: '', email: '' });
 
+// ESC 키를 감지하는 전용 함수
+const handleKeydown = (event) => {
+  // 모달이 열려있고 && 누른 키가 'Escape'라면
+  if (isModalOpen.value && event.key === 'Escape') {
+    closeEditModal(); // 모달 닫기
+  }
+};
+
 const openEditModal = () => {
   // 모달을 열 때, 기존 데이터를 폼에 채워줍니다.
   editForm.nickname = props.user.nickname;
   editForm.email = props.user.email;
   isModalOpen.value = true;
+  window.addEventListener('keydown', handleKeydown);
 };
 
 const closeEditModal = () => {
   isModalOpen.value = false;
+  window.removeEventListener('keydown', handleKeydown);
 };
 
 const saveProfile = () => {
@@ -138,6 +152,9 @@ const saveProfile = () => {
   });
   closeEditModal();
 };
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown);
+});
 </script>
 
 <style scoped>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -72,7 +72,7 @@ import SettingMenuList from '@/components/settings/SettingMenuList.vue';
 // 🌟 db.json 구조를 참고한 Mock Data 상태 관리
 const userData = reactive({
   email: 'jisu@email.com',
-  imgUrl: 'awdawd',
+  imgUrl: '',
   nickname: '박지수',
 });
 


### PR DESCRIPTION
## 🚀 작업 내용
> 프로필 수정 모달 창 활성화 시 ESC 키를 통해 창을 닫을 수 있도록 하고, 텍스트 드래그 중 오버레이 영역으로 마우스가 벗어날 때 의도치 않게 모달이 닫히는 현상을 방지하여 UI/UX를 개선했습니다.
- 프로필 수정 모달 창 ESC로 창 닫기 기능
- 마우스 클릭 시 오버레이 영역으로 마우스가 벗어날 때 모달이 닫히는 현상 개선

## 📝 구현한 상세 작업
- [x] 오버레이 배경 닫기 이벤트를 @click에서 @mousedown.self로 변경하여 내부 요소 드래그 시 발생하는 닫힘 버그 해결
- [x] 모달 활성화 시 window 객체에 전역 keydown 이벤트 리스너를 등록하여 ESC(Escape) 키 감지 및 종료 로직 연동
- [x] 메모리 누수 방지를 위해 onUnmounted 생명주기 훅을 활용하여 컴포넌트 파괴 시 키보드 이벤트 리스너 해제 처리

## 🔗 관련 이슈
- Resolves: #15 