### PR TITLE
[Feat] 캘린더 페이지 API 연동

### DIFF
--- a/src/api/calendar.js
+++ b/src/api/calendar.js
@@ -5,11 +5,17 @@ export const getAllTransactions = () => {
   return apiClient.get('/transactions');
 };
 
+// 고정 지출 내역 가져오기
 export const getFixedDetails = () => {
   return apiClient.get('/fixed_details');
 };
 
-// 고정 지출 추가 (POST)
-export const addFixedExpense = (data) => {
+// 고정 지출 신규 생성 (해당 월 데이터가 아예 없을 때)
+export const createFixedExpense = (data) => {
   return apiClient.post('/fixed_details', data);
+};
+
+// 고정 지출 수정 (해당 월 데이터가 이미 있을 때)
+export const updateFixedExpense = (id, data) => {
+  return apiClient.put(`/fixed_details/${id}`, data);
 };

--- a/src/api/calendar.js
+++ b/src/api/calendar.js
@@ -5,7 +5,11 @@ export const getAllTransactions = () => {
   return apiClient.get('/transactions');
 };
 
+export const getFixedDetails = () => {
+  return apiClient.get('/fixed_details');
+};
+
 // 고정 지출 추가 (POST)
 export const addFixedExpense = (data) => {
-  return apiClient.post('/fixedExpenses', data);
+  return apiClient.post('/fixed_details', data);
 };

--- a/src/api/calendar.js
+++ b/src/api/calendar.js
@@ -1,0 +1,11 @@
+import apiClient from './index';
+
+// 필터 없이 전체 거래 내역 가져오기
+export const getAllTransactions = () => {
+  return apiClient.get('/transactions');
+};
+
+// 고정 지출 추가 (POST)
+export const addFixedExpense = (data) => {
+  return apiClient.post('/fixedExpenses', data);
+};

--- a/src/components/calendar/AccountBox.vue
+++ b/src/components/calendar/AccountBox.vue
@@ -4,6 +4,7 @@
     <p>₩{{ account.balance }}</p>
   </div>
 </template>
+
 <script setup>
 defineProps({
   account: {

--- a/src/components/calendar/AccountBox.vue
+++ b/src/components/calendar/AccountBox.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container" :class="account.type">
     <span>{{ account.name }}</span>
-    <p>₩{{ account.balance }}</p>
+    <p>₩ {{ account.balance }}</p>
   </div>
 </template>
 

--- a/src/components/calendar/FixedExpenseModal.vue
+++ b/src/components/calendar/FixedExpenseModal.vue
@@ -12,9 +12,9 @@
             <div class="input-group">
               <label>고정지출 월</label>
               <input
-                type="text"
+                type="number"
                 v-model="expenseData.month"
-                placeholder="예: 4월"
+                placeholder="예: 4"
                 class="input-dark"
               />
             </div>
@@ -34,7 +34,7 @@
               <div class="amount-input-wrapper">
                 <span class="currency">₩</span>
                 <input
-                  type="text"
+                  type="number"
                   v-model="expenseData.amount"
                   placeholder="0"
                   class="input-dark amount-input"
@@ -55,6 +55,7 @@
 
 <script setup>
 import { reactive, watch } from 'vue';
+import { useCalendarStore } from '@/store/calendar';
 
 // 부모에게서 모달 노출 여부를 props로 받습니다.
 const props = defineProps({
@@ -64,11 +65,18 @@ const props = defineProps({
 // 부모에게 닫기(close)와 저장(save) 신호를 보냅니다.
 const emit = defineEmits(['close', 'save']);
 
+const calendarStore = useCalendarStore(); // 2. 스토어 사용 준비
+
+const getCurrentMonthNum = () => {
+  // 스토어의 "2026-04" 형태에서 "04"를 떼어내 숫자로 변환
+  return parseInt(calendarStore.currentYearMonth.split('-')[1]);
+};
+
 // 입력 폼 데이터를 저장할 반응형 객체
 const expenseData = reactive({
-  month: '',
+  month: getCurrentMonthNum(),
   title: '',
-  amount: '',
+  amount: 0,
 });
 
 // 모달이 열릴 때마다 입력 폼 초기화 (선택 사항)
@@ -76,9 +84,9 @@ watch(
   () => props.show,
   (newVal) => {
     if (newVal) {
-      expenseData.month = '';
+      expenseData.month = getCurrentMonthNum();
       expenseData.title = '';
-      expenseData.amount = '';
+      expenseData.amount = 0;
     }
   },
 );
@@ -91,7 +99,7 @@ const save = () => {
   // 간단한 유효성 검사 (금액 숫자 변환 등) 후 부모에게 데이터 전달
   const finalData = {
     ...expenseData,
-    amount: parseInt(expenseData.amount.replace(/,/g, '')) || 0, // 쉼표 제거 후 숫자로 변환
+    amount: expenseData.amount || 0,
   };
 
   if (!finalData.month || !finalData.title || finalData.amount === 0) {
@@ -99,7 +107,6 @@ const save = () => {
     return;
   }
 
-  console.log('고정지출 저장:', finalData);
   emit('save', finalData); // 부모에게 데이터 전달
   close(); // 저장 후 닫기
 };

--- a/src/components/calendar/FullCalendar.vue
+++ b/src/components/calendar/FullCalendar.vue
@@ -10,29 +10,33 @@
 import FullCalendar from '@fullcalendar/vue3';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
-import { onMounted } from 'vue';
+import { onMounted, computed } from 'vue';
 
-// 부모(App)에서 전달받은 월별 데이터
-// [{ date, income, expense, items: [] }]
 const props = defineProps({
-  monthlyData: Array,
+  dailyDataMap: Object, // 부모가 준 날짜별 요약 데이터
   currentDate: String,
 });
 
-// 부모로 이벤트 전달 (날짜 선택)
-const emit = defineEmits(['dateSelect']);
+const emit = defineEmits(['dateSelect', 'changeMonth']);
 
+/* --- 💡 날짜 선택 스타일 유지 (건드리지 않음) --- */
 const selectDay = (dateStr, dayEl) => {
-  // 기존 선택된 날짜 스타일 제거
   document
     .querySelectorAll('.fc-daygrid-day')
     .forEach((el) => el.classList.remove('selected-day'));
 
-  // 현재 클릭한 날짜에 클래스 추가
   if (dayEl) dayEl.classList.add('selected-day');
-
-  // 부모 컴포넌트로 선택된 날짜 전달
   emit('dateSelect', dateStr);
+};
+
+const handleDatesSet = (arg) => {
+  // arg.view.currentStart는 해당 월의 1일 날짜를 가리킵니다.
+  const year = arg.view.currentStart.getFullYear();
+  const month = String(arg.view.currentStart.getMonth() + 1).padStart(2, '0');
+  const yearMonth = `${year}-${month}`;
+
+  // 부모에게 현재 달력에 보이는 연-월을 보냄
+  emit('changeMonth', yearMonth);
 };
 
 const handleDateClick = (info) => {
@@ -40,70 +44,80 @@ const handleDateClick = (info) => {
 };
 
 const handleEventClick = (info) => {
-  // 이벤트가 속한 날짜 셀 찾기
   const dayEl = info.el.closest('.fc-daygrid-day');
   selectDay(info.event.startStr, dayEl);
 };
 
-// 🔥 컴포넌트 마운트 후 오늘 날짜 자동 선택 스타일 적용
 onMounted(() => {
   setTimeout(() => {
-    const todayEl = document.querySelector(`.fc-day-today[data-date="${props.currentDate}"]`);
+    const todayEl = document.querySelector(
+      `.fc-daygrid-day[data-date="${props.currentDate}"]`,
+    );
     if (todayEl) {
       todayEl.classList.add('selected-day');
     }
-  }, 50);
+  }, 100); // 데이터 로딩 시간을 고려해 약간의 딜레이
 });
 
-// 🔥 FullCalendar에 넣을 이벤트 데이터 생성
-// monthlyData → items → 이벤트로 변환
-const events = props.monthlyData.flatMap((day) =>
-  day.items.map((item) => ({
-    date: day.date, // 이벤트 날짜
-    extendedProps: item, // 추가 데이터 (amount, category 등)
-  })),
-);
+/* --- 📊 데이터 연동: 수입/지출 합계 요약 --- */
+const events = computed(() => {
+  if (!props.dailyDataMap) return [];
 
-// 🔥 이벤트(금액) 커스텀 렌더링
+  return Object.values(props.dailyDataMap).flatMap((day) => {
+    const dailyEvents = [];
+    if (day.income > 0) {
+      dailyEvents.push({
+        date: day.date,
+        order: 1, // 수입 위로
+        extendedProps: { amount: day.income, type: 'income' },
+      });
+    }
+    if (day.expense > 0) {
+      dailyEvents.push({
+        date: day.date,
+        order: 2, // 지출 아래로
+        extendedProps: { amount: day.expense, type: 'expense' },
+      });
+    }
+    return dailyEvents;
+  });
+});
+
 const renderEvent = (arg) => {
-  const { amount } = arg.event.extendedProps;
+  const { amount, type } = arg.event.extendedProps;
+  const color = type === 'income' ? '#4dabf7' : '#ff6b6b';
+  const prefix = type === 'income' ? '+' : '-';
+
   return {
     html: `
-      <div style="font-size:11px; text-align:center;">
-        <div style="color:${amount > 0 ? '#4dabf7' : '#ff6b6b'}">
-          ${amount > 0 ? '+' : ''}${amount.toLocaleString()}
-        </div>
+      <div style="font-size:12px; font-weight: 700; text-align: right; width: 100%; padding-right: 4px; color: ${color};">
+        ${prefix}${amount.toLocaleString()}
       </div>
     `,
   };
 };
 
-// 🔥 FullCalendar 전체 설정
-const calendarOptions = {
+/* --- ⚙️ 캘린더 설정 --- */
+const calendarOptions = computed(() => ({
   plugins: [dayGridPlugin, interactionPlugin],
   initialView: 'dayGridMonth',
-  initialDate: props.currentDate, // 초기 달력 세팅 날짜 지정
-  
-  // 상단 헤더 (이전 / 제목 / 다음)
+  initialDate: props.currentDate,
   headerToolbar: {
     left: 'prev title next',
     center: '',
     right: '',
   },
-
-  fixedWeekCount: false, // 달마다 주 수 맞춤 (빈 줄 제거)
-  dateClick: handleDateClick, // 날짜 클릭 이벤트
-  eventClick: handleEventClick, // 지출, 수입 클릭 이벤트
-  events: events, // 우리가 만든 이벤트 데이터
-  eventContent: renderEvent, // 이벤트 커스텀 렌더링
+  fixedWeekCount: false,
+  dateClick: handleDateClick,
+  eventClick: handleEventClick,
+  datesSet: handleDatesSet,
+  events: events.value,
+  eventOrder: 'order',
+  eventContent: renderEvent,
   locale: 'ko',
-
-  // 날짜 숫자만 표시 (1일 → 1)
-  dayCellContent: (arg) => {
-    return arg.date.getDate();
-  },
+  dayCellContent: (arg) => arg.date.getDate(),
   contentHeight: 'auto',
-};
+}));
 </script>
 
 <style scoped>

--- a/src/components/calendar/FullCalendar.vue
+++ b/src/components/calendar/FullCalendar.vue
@@ -232,6 +232,7 @@ const calendarOptions = computed(() => ({
 }
 
 :deep(th) {
+  font-size: 18px;
   color: #364153;
 }
 </style>

--- a/src/components/calendar/TransactionDetail.vue
+++ b/src/components/calendar/TransactionDetail.vue
@@ -11,14 +11,14 @@
     <div class="card summary-card">
       <div class="summary-item income">
         <p>수입</p>
-        <h3>₩{{ selectedData?.income.toLocaleString() || 0 }}</h3>
+        <h3>₩ {{ selectedData?.income.toLocaleString() || 0 }}</h3>
       </div>
 
       <div class="divider"></div>
 
       <div class="summary-item expense">
         <p>지출</p>
-        <h3>₩{{ selectedData?.expense.toLocaleString() || 0 }}</h3>
+        <h3>₩ {{ selectedData?.expense.toLocaleString() || 0 }}</h3>
       </div>
     </div>
 

--- a/src/components/calendar/TransactionDetail.vue
+++ b/src/components/calendar/TransactionDetail.vue
@@ -35,8 +35,12 @@
             <span class="category">{{ item.category }}</span>
           </div>
 
-          <div class="amount" :class="item.amount > 0 ? 'income' : 'expense'">
-            ₩ {{ item.amount > 0 ? '+' : '' }}{{ item.amount.toLocaleString() }}
+          <div
+            class="amount"
+            :class="item.type === 'income' ? 'income' : 'expense'"
+          >
+            ₩ {{ item.type === 'income' ? '+' : '-'
+            }}{{ Math.abs(item.amount).toLocaleString() }}
           </div>
         </div>
       </div>

--- a/src/store/calendar.js
+++ b/src/store/calendar.js
@@ -1,0 +1,70 @@
+import { defineStore } from 'pinia';
+import { ref, computed, readonly } from 'vue';
+import { getAllTransactions } from '@/api/calendar';
+
+export const useCalendarStore = defineStore('calendar', () => {
+  const _allList = ref([]);
+  const _loading = ref(false);
+
+  // 현재 캘린더가 보여주고 있는 연-월 (기본값: 오늘 날짜의 YYYY-MM)
+  const currentYearMonth = ref(new Date().toISOString().slice(0, 7));
+
+  // 1. [월별 합계] - 현재 설정된 currentYearMonth에 해당하는 데이터만 합계
+  const monthlySummary = computed(() => {
+    const filtered = _allList.value.filter((t) =>
+      t.date.startsWith(currentYearMonth.value),
+    );
+
+    const income = filtered
+      .filter((t) => t.type === 'income')
+      .reduce((sum, t) => sum + t.amount, 0);
+    const expense = filtered
+      .filter((t) => t.type === 'expense')
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    return {
+      income,
+      expense,
+      profit: income - expense,
+      month: currentYearMonth.value.split('-')[1], // "04" 같은 월 정보
+    };
+  });
+
+  // 2. [날짜별 그룹화] - (이전과 동일)
+  const dailyDataMap = computed(() => {
+    return _allList.value.reduce((acc, cur) => {
+      if (!acc[cur.date]) {
+        acc[cur.date] = { date: cur.date, income: 0, expense: 0, items: [] };
+      }
+      if (cur.type === 'income') acc[cur.date].income += cur.amount;
+      else acc[cur.date].expense += cur.amount;
+      acc[cur.date].items.push(cur);
+      return acc;
+    }, {});
+  });
+
+  const fetchAllData = async () => {
+    _loading.value = true;
+    try {
+      const res = await getAllTransactions();
+      _allList.value = res.data || res;
+    } finally {
+      _loading.value = false;
+    }
+  };
+
+  // 외부에서 연-월을 변경할 수 있는 함수
+  const setCurrentMonth = (dateStr) => {
+    currentYearMonth.value = dateStr.slice(0, 7);
+  };
+
+  return {
+    allList: readonly(_allList),
+    currentYearMonth,
+    monthlySummary,
+    dailyDataMap,
+    fetchAllData,
+    setCurrentMonth,
+    loading: readonly(_loading),
+  };
+});

--- a/src/store/calendar.js
+++ b/src/store/calendar.js
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia';
 import { ref, computed, readonly } from 'vue';
-import { getAllTransactions, getFixedDetails } from '@/api/calendar';
+import {
+  getAllTransactions,
+  getFixedDetails,
+  createFixedExpense,
+  updateFixedExpense,
+} from '@/api/calendar';
 
 export const useCalendarStore = defineStore('calendar', () => {
   const _allList = ref([]);
@@ -10,7 +15,7 @@ export const useCalendarStore = defineStore('calendar', () => {
   // 현재 캘린더가 보여주고 있는 연-월 (기본값: 오늘 날짜의 YYYY-MM)
   const currentYearMonth = ref(new Date().toISOString().slice(0, 7));
 
-  // 데이터 가져오기 (고정 지출 포함)
+  // 모든 거래내역 데이터 가져오기 (고정 지출 포함)
   const fetchAllData = async () => {
     _loading.value = true;
     try {
@@ -21,10 +26,14 @@ export const useCalendarStore = defineStore('calendar', () => {
     }
   };
 
-  const fetchFixedDate = async () => {
+  const fetchFixedData = async () => {
     _loading.value = true;
     try {
       const res = await getFixedDetails();
+      console.log(
+        '고정 지출 데이터:',
+        res.data.find((f) => f.month === 4) || res,
+      ); // 디버깅용 로그
       _fixedList.value = res.data || res;
     } finally {
       _loading.value = false;
@@ -78,14 +87,85 @@ export const useCalendarStore = defineStore('calendar', () => {
     currentYearMonth.value = dateStr.slice(0, 7);
   };
 
+  // 공통 로직: 수정된 아이템 배열을 받아서 합계를 계산하고 서버에 PUT 하는 함수
+  const _updateFixedMonth = async (monthId, updatedItems) => {
+    const newTotal = updatedItems.reduce((sum, item) => sum + item.expense, 0);
+    const target = _fixedList.value.find((f) => f.id === monthId);
+
+    const updatedObject = {
+      ...target,
+      total_fixed_expense: newTotal,
+      items: updatedItems,
+    };
+
+    await updateFixedExpense(monthId, updatedObject);
+    await fetchFixedData(); // 최신 고정지출 갱신
+  };
+
+  // 1. 추가 로직
+  const addFixedItem = async (month, name, expense) => {
+    const allItems = _fixedList.value.flatMap((f) => f.items);
+    let nextId;
+    if (allItems.length === 0) {
+      nextId = 1; // 데이터가 하나도 없을 때 1번 부여
+    } else {
+      // Math.max를 이용해 가장 큰 id를 찾고 +1
+      const maxId = Math.max(...allItems.map((item) => item.id));
+      nextId = maxId + 1;
+    }
+
+    const target = _fixedList.value.find((f) => f.month === month);
+    if (target) {
+      const newItems = [...target.items, { id: nextId, name, expense }];
+      await _updateFixedMonth(target.id, newItems);
+    } else {
+      // 해당 월 데이터가 아예 없으면 POST
+      await createFixedExpense({
+        month,
+        total_fixed_expense: expense,
+        items: [{ id: nextId, name, expense }],
+      });
+
+      await fetchFixedData();
+    }
+  };
+
+  // 2. 수정 로직 (아이템 하나만 선택해서 수정)
+  // const editFixedItem = async (monthId, itemId, newName, newExpense) => {
+  //   const target = _fixedList.value.find((f) => f.id === monthId);
+  //   if (!target) return;
+
+  //   const updatedItems = target.items.map((item) =>
+  //     item.id === itemId
+  //       ? { ...item, name: newName, expense: newExpense }
+  //       : item,
+  //   );
+
+  //   await _updateFixedMonth(monthId, updatedItems);
+  // };
+
+  // 3. 삭제 로직 (아이템 하나만 선택해서 삭제)
+  // const deleteFixedItem = async (monthId, itemId) => {
+  //   const target = _fixedList.value.find((f) => f.id === monthId);
+  //   if (!target) return;
+
+  //   // 해당 ID만 제외하고 필터링
+  //   const updatedItems = target.items.filter((item) => item.id !== itemId);
+
+  //   await _updateFixedMonth(monthId, updatedItems);
+  // };
+
   return {
     allList: readonly(_allList),
     fixedList: readonly(_fixedList),
     currentYearMonth,
     monthlySummary,
     dailyDataMap,
-    fetchFixedDate,
+    fetchFixedData,
     fetchAllData,
+    addFixedItem,
+    // editFixedItem,
+    // deleteFixedItem,
     setCurrentMonth,
     loading: readonly(_loading),
   };

--- a/src/store/calendar.js
+++ b/src/store/calendar.js
@@ -1,16 +1,39 @@
 import { defineStore } from 'pinia';
 import { ref, computed, readonly } from 'vue';
-import { getAllTransactions } from '@/api/calendar';
+import { getAllTransactions, getFixedDetails } from '@/api/calendar';
 
 export const useCalendarStore = defineStore('calendar', () => {
   const _allList = ref([]);
+  const _fixedList = ref([]);
   const _loading = ref(false);
 
   // 현재 캘린더가 보여주고 있는 연-월 (기본값: 오늘 날짜의 YYYY-MM)
   const currentYearMonth = ref(new Date().toISOString().slice(0, 7));
 
-  // 1. [월별 합계] - 현재 설정된 currentYearMonth에 해당하는 데이터만 합계
+  // 데이터 가져오기 (고정 지출 포함)
+  const fetchAllData = async () => {
+    _loading.value = true;
+    try {
+      const res = await getAllTransactions();
+      _allList.value = res.data || res;
+    } finally {
+      _loading.value = false;
+    }
+  };
+
+  const fetchFixedDate = async () => {
+    _loading.value = true;
+    try {
+      const res = await getFixedDetails();
+      _fixedList.value = res.data || res;
+    } finally {
+      _loading.value = false;
+    }
+  };
+
+  // [월별 합계] - 변동 지출 + 고정 지출 합산
   const monthlySummary = computed(() => {
+    // A. 변동 지출 필터링
     const filtered = _allList.value.filter((t) =>
       t.date.startsWith(currentYearMonth.value),
     );
@@ -18,19 +41,26 @@ export const useCalendarStore = defineStore('calendar', () => {
     const income = filtered
       .filter((t) => t.type === 'income')
       .reduce((sum, t) => sum + t.amount, 0);
-    const expense = filtered
+
+    const variableExpense = filtered
       .filter((t) => t.type === 'expense')
       .reduce((sum, t) => sum + t.amount, 0);
 
+    // B. 고정 지출 찾기
+    const currentMonthNum = parseInt(currentYearMonth.value.split('-')[1]);
+    const fixedData = _fixedList.value.find((f) => f.month === currentMonthNum);
+    const fixedExpense = fixedData ? fixedData.total_fixed_expense : 0;
+
     return {
       income,
-      expense,
-      profit: income - expense,
-      month: currentYearMonth.value.split('-')[1], // "04" 같은 월 정보
+      expense: variableExpense + fixedExpense, // 💡 변동 + 고정 지출 합산
+      fixedExpense, // 필요시 별도로 확인하기 위해 추가
+      profit: income - (variableExpense + fixedExpense),
+      month: currentYearMonth.value.split('-')[1],
     };
   });
 
-  // 2. [날짜별 그룹화] - (이전과 동일)
+  // [날짜별 그룹화] - (이전과 동일)
   const dailyDataMap = computed(() => {
     return _allList.value.reduce((acc, cur) => {
       if (!acc[cur.date]) {
@@ -43,16 +73,6 @@ export const useCalendarStore = defineStore('calendar', () => {
     }, {});
   });
 
-  const fetchAllData = async () => {
-    _loading.value = true;
-    try {
-      const res = await getAllTransactions();
-      _allList.value = res.data || res;
-    } finally {
-      _loading.value = false;
-    }
-  };
-
   // 외부에서 연-월을 변경할 수 있는 함수
   const setCurrentMonth = (dateStr) => {
     currentYearMonth.value = dateStr.slice(0, 7);
@@ -60,9 +80,11 @@ export const useCalendarStore = defineStore('calendar', () => {
 
   return {
     allList: readonly(_allList),
+    fixedList: readonly(_fixedList),
     currentYearMonth,
     monthlySummary,
     dailyDataMap,
+    fetchFixedDate,
     fetchAllData,
     setCurrentMonth,
     loading: readonly(_loading),

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -55,9 +55,21 @@ const calendarStore = useCalendarStore();
 const route = useRoute();
 const isModalOpen = ref(false);
 
+/* --- 날짜 선택 관련 로직 --- */
+const getToday = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const selectedDate = ref(route.query.date || getToday());
+
 // 데이터 로드
 onMounted(async () => {
   await calendarStore.fetchAllData();
+  await calendarStore.fetchFixedDate();
 });
 
 /* --- 상단 계좌 정보 데이터 --- */
@@ -85,17 +97,6 @@ const accounts = computed(() => {
   ];
 });
 
-/* --- 날짜 선택 관련 로직 --- */
-const getToday = () => {
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = String(today.getMonth() + 1).padStart(2, '0');
-  const day = String(today.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
-const selectedDate = ref(route.query.date || getToday());
-
 const handleDateSelect = (date) => {
   selectedDate.value = date;
 };
@@ -107,12 +108,16 @@ const handleMonthChange = (yearMonth) => {
 
 // 상세 내역에 전달할 데이터 (Store에서 선택 날짜만 쏙)
 const selectedData = computed(() => {
+  // 1. dailyDataMap이 아직 로드되지 않았을 경우를 대비한 방어 코드
+  if (!calendarStore.dailyDataMap) {
+    return { items: [], income: 0, expense: 0 };
+  }
+
+  const dateKey = selectedDate.value;
+
+  // 2. 해당 날짜에 데이터가 있으면 반환, 없으면 기본값 반환
   return (
-    calendarStore.dailyDataMap[selectedDate.value] || {
-      items: [],
-      income: 0,
-      expense: 0,
-    }
+    calendarStore.dailyDataMap[dateKey] || { items: [], income: 0, expense: 0 }
   );
 });
 

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -69,7 +69,7 @@ const selectedDate = ref(route.query.date || getToday());
 // 데이터 로드
 onMounted(async () => {
   await calendarStore.fetchAllData();
-  await calendarStore.fetchFixedDate();
+  await calendarStore.fetchFixedData();
 });
 
 /* --- 상단 계좌 정보 데이터 --- */
@@ -128,9 +128,18 @@ const handleButtonAction = (type) => {
   }
 };
 
-const saveFixedExpense = (newExpense) => {
-  console.log('저장 데이터:', newExpense);
-  isModalOpen.value = false;
+const saveFixedExpense = async (newExpense) => {
+  try {
+    const { month, title, amount } = newExpense;
+
+    await calendarStore.addFixedItem(month, title, amount);
+
+    alert('고정 지출이 저장되었습니다!');
+    isModalOpen.value = false;
+  } catch (error) {
+    console.error('저장 중 오류 발생:', error);
+    alert('저장에 실패했습니다.');
+  }
 };
 
 const adds = [

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -8,11 +8,14 @@
           :account="account"
         />
       </div>
-      <FullCalendar 
-        :monthlyData="monthlyData"
+
+      <FullCalendar
+        :dailyDataMap="calendarStore.dailyDataMap"
         @dateSelect="handleDateSelect"
         :currentDate="selectedDate"
+        @changeMonth="handleMonthChange"
       />
+
       <div class="button-row">
         <Button
           v-for="add in adds"
@@ -21,11 +24,13 @@
           @action="handleButtonAction"
         />
       </div>
+
       <FixedExpenseModal
         :show="isModalOpen"
         @close="isModalOpen = false"
         @save="saveFixedExpense"
       />
+
       <div class="transaction">
         <TransactionDetail
           :selectedDate="selectedDate"
@@ -41,32 +46,46 @@ import AccountBox from '@/components/calendar/AccountBox.vue';
 import FullCalendar from '@/components/calendar/FullCalendar.vue';
 import Button from '@/components/calendar/Button.vue';
 import TransactionDetail from '@/components/calendar/TransactionDetail.vue';
-import { ref, computed } from 'vue';
-import { useRoute } from 'vue-router';
 import FixedExpenseModal from '@/components/calendar/FixedExpenseModal.vue';
+import { ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { useCalendarStore } from '@/store/calendar';
 
+const calendarStore = useCalendarStore();
 const route = useRoute();
-
-// ⭐ 모달 오픈 상태 관리 변수
 const isModalOpen = ref(false);
 
-const handleButtonAction = (type) => {
-  if (type === 'fixedExpenses') {
-    // 💡 "+ 고정지출 추가" 버튼 클릭 시 모달 오픈
-    isModalOpen.value = true;
-    console.log(type);
-  }
-  // ... 다른 버튼 로직 생략 ...
-};
+// 데이터 로드
+onMounted(async () => {
+  await calendarStore.fetchAllData();
+});
 
-// ⭐ 모달에서 '저장' 버튼을 눌렀을 때 실행될 함수
-const saveFixedExpense = (newExpense) => {
-  // 💡 여기서 실제 DB 저장 API를 호출하거나, monthlyData를 업데이트하는 로직을 넣으세요.
-  console.log('부모에서 받은 저장 데이터:', newExpense);
-  alert(`"${newExpense.title}" 고정지출이 저장되었습니다.`);
-};
+/* --- 상단 계좌 정보 데이터 --- */
+const accounts = computed(() => {
+  const summary = calendarStore.monthlySummary;
+  return [
+    {
+      id: 1,
+      name: `${summary.month}월 총 수입`,
+      balance: summary.income.toLocaleString(),
+      type: 'totalIncome',
+    },
+    {
+      id: 2,
+      name: `${summary.month}월 총 지출`,
+      balance: summary.expense.toLocaleString(),
+      type: 'totalExpenditure',
+    },
+    {
+      id: 3,
+      name: '순수익',
+      balance: summary.profit.toLocaleString(),
+      type: 'profit',
+    },
+  ];
+});
 
-/* 🔥 오늘 날짜 */
+/* --- 날짜 선택 관련 로직 --- */
 const getToday = () => {
   const today = new Date();
   const year = today.getFullYear();
@@ -75,43 +94,39 @@ const getToday = () => {
   return `${year}-${month}-${day}`;
 };
 
-/* route.params.date 에 값이 있으면 그 값을 사용하고, 없으면 getToday() 실행 */
 const selectedDate = ref(route.query.date || getToday());
 
-/* 🔥 FullCalendar에서 날짜 받기 */
 const handleDateSelect = (date) => {
   selectedDate.value = date;
 };
-const monthlyData = [
-  {
-    date: '2026-04-06',
-    income: 200000,
-    expense: 45000,
-    items: [
-      { id: 1, title: '월급', category: '급여', amount: 200000 },
-      { id: 2, title: '점심', category: '식비', amount: -12000 },
-    ],
-  },
-  {
-    date: '2026-04-11',
-    income: 100000,
-    expense: 20000,
-    items: [{ id: 3, title: '용돈', category: '기타', amount: 100000 }],
-  },
-];
 
+const handleMonthChange = (yearMonth) => {
+  // 스토어의 기준 월을 업데이트함 -> monthlySummary가 자동으로 재계산됨
+  calendarStore.setCurrentMonth(yearMonth);
+};
+
+// 상세 내역에 전달할 데이터 (Store에서 선택 날짜만 쏙)
 const selectedData = computed(() => {
-  const result = monthlyData.find((d) => {
-    return d.date === selectedDate.value;
-  });
-  return result;
+  return (
+    calendarStore.dailyDataMap[selectedDate.value] || {
+      items: [],
+      income: 0,
+      expense: 0,
+    }
+  );
 });
 
-const accounts = [
-  { id: 1, name: '총 수입', balance: '3,600,000', type: 'totalIncome' },
-  { id: 2, name: '총 지출', balance: '2,850,000', type: 'totalExpenditure' },
-  { id: 3, name: '순수익', balance: '650,000', type: 'profit' },
-];
+/* --- 버튼 및 모달 로직 --- */
+const handleButtonAction = (type) => {
+  if (type === 'fixedExpenses') {
+    isModalOpen.value = true;
+  }
+};
+
+const saveFixedExpense = (newExpense) => {
+  console.log('저장 데이터:', newExpense);
+  isModalOpen.value = false;
+};
 
 const adds = [
   { id: 1, name: '+ 거래 추가', type: 'transaction' },
@@ -124,39 +139,32 @@ const adds = [
 .body {
   background-color: #000;
   display: flex;
-  justify-content: center; /* 가로 중앙 정렬 */
+  justify-content: center;
 }
-
 .wrapper {
   width: 100%;
   max-width: 1000px;
   display: flex;
-  flex-direction: column; /* 세로로 쌓기 */
+  flex-direction: column;
   padding-bottom: 80px;
 }
-
 .account-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 0 10px;
   width: 100%;
-  justify-items: center; /* 내부 아이템 중앙 정렬 */
+  justify-items: center;
 }
-
-/* 2. 하단 버튼 영역 (그리드로 수정) */
 .button-row {
   display: grid;
-  /* 버튼은 박스보다 조금 더 작아도 예쁘니 280px 정도로 설정해 볼게요 */
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 0 10px;
   width: 100%;
   justify-items: center;
 }
-
 .account-row > *,
 .button-row > * {
   width: 100%;
-  /* 창이 아주 넓어질 때 혼자 너무 길어지지 않도록 피그마 느낌의 너비 제한 */
   max-width: 300px;
 }
 </style>


### PR DESCRIPTION
## 🚀 작업 내용
> 캘린더 페이지 API 연동 및 모달창 데이터 타입 변경

## 📝 구현한 상세 작업
- [ ] 사용자의 거래 내역 전체 조회, 고정 지출 조회를 통해 캘린더 UI에 뿌려줌
- [ ] 고정 지출 추가 API 연동 하여 고정 지출 추가 시 다시 전체 고정 지출 조회를 하여 화면에 바로 뿌려줌
- [ ] modal창에서 입력받는 월, 금액 부분 text로 받던거 number로 수정

## 🔗 관련 이슈
- Resolves: #54 

## 📸 스크린샷
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/17ef576b-68ba-4088-b3c9-e02dd4733273" />
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/b063f681-e9ac-4561-a5fb-23ae73ac5a24" />

### 🚨 트러블 슈팅(선택)
