### PR TITLE
[Fix] 모달 내부에서 드래그 시작 후 외부에서 마우스를 뗄 때 창이 닫히는 현상 수정

### DIFF
--- a/src/components/transaction-modal/ReceiptModal.vue
+++ b/src/components/transaction-modal/ReceiptModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="modal-overlay" @click.self="handleClose">
+  <div
+    class="modal-overlay"
+    @mousedown="onMouseDownOverlay"
+    @mouseup="onMouseUpOverlay"
+  >
     <div class="modal-content">
       <div class="receipt-container" :class="{ tearing: isDeleting }">
         <div
@@ -211,6 +215,25 @@ import { onMounted, onUnmounted, ref, computed } from 'vue';
 import { useTransactionStore } from '@/store/transactions';
 import receiptSvg from '@/assets/icons/receipt.svg';
 
+const isMouseDownOnOverlay = ref(false); // 배경에서 마우스 누름 시작 여부
+
+// 마우스를 누를 때 실행
+const onMouseDownOverlay = (e) => {
+  // 정확히 '배경(Overlay)' 부분을 눌렀을 때만 true로 설정
+  if (e.target === e.currentTarget) {
+    isMouseDownOnOverlay.value = true;
+  }
+};
+
+// 마우스를 뗄 때 실행
+const onMouseUpOverlay = (e) => {
+  // 눌렀을 때도 배경이었고, 뗄 때도 배경 위라면 모달 닫기 실행
+  if (isMouseDownOnOverlay.value && e.target === e.currentTarget) {
+    handleClose();
+  }
+  // 상태값 초기화 (드래그가 끝났으므로)
+  isMouseDownOnOverlay.value = false;
+};
 const props = defineProps({
   transaction: {
     type: Object,


### PR DESCRIPTION
## 🚀 작업 내용
> 사용자가 모달 내부(영수증)에서 드래그를 시작하여 모달 외부(Backdrop)에서 마우스 버튼을 뗐을 때, 의도치 않게 모달이 닫히는 UX 오류 해결


## 📝 구현한 상세 작업
- [x] `click` 이벤트 대신 `mousedown`과 `mouseup` 타겟을 비교하는 로직 검토
- [x] 모달 외부 배경(Backdrop)의 이벤트 핸들러가 내부 드래그 종료에 반응하지 않도록 수정
- [x] 텍스트 드래그 또는 실수에 의한 모달 이탈 방지

## 🔗 관련 이슈
- Resolves: #74 