### PR TITLE
fix: 홈화면 고정지출 랜더링 필드값 일치시킴

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -682,6 +682,20 @@
       "day": 13,
       "start_date": "2025-06-13",
       "id": 8
+    },
+    {
+      "title": "ㅇㅇㅇ",
+      "expense": 22222,
+      "day": 21,
+      "start_date": "2026-05-21",
+      "id": 9
+    },
+    {
+      "title": "기후동행카드",
+      "expense": 50000,
+      "day": 9,
+      "start_date": "2026-04-09",
+      "id": 10
     }
   ],
   "categories": [

--- a/src/api/home.js
+++ b/src/api/home.js
@@ -11,8 +11,8 @@ export const getAllMonthlyStats = () => {
 };
 
 // 3. 고정 지출 내역
-export const getFixedDetails = (month) => {
-  return apiClient.get(`/fixed_details?month=${month}`);
+export const getFixedDetails = () => {
+  return apiClient.get('/fixed_details');
 };
 
 // 4. 카테고리별 통계

--- a/src/components/home/FixedExpenseSummary.vue
+++ b/src/components/home/FixedExpenseSummary.vue
@@ -22,13 +22,13 @@ const fixedExpenses = computed(() => {
     },
     {
       id: topTwoItems[0]?.id ?? 'top1',
-      label: topTwoItems[0]?.name ?? '-',
+      label: topTwoItems[0]?.title ?? '-',
       amount: formatAmount(topTwoItems[0]?.expense ?? 0),
       color: 'purple',
     },
     {
       id: topTwoItems[1]?.id ?? 'top2',
-      label: topTwoItems[1]?.name ?? '-',
+      label: topTwoItems[1]?.title ?? '-',
       amount: formatAmount(topTwoItems[1]?.expense ?? 0),
       color: 'pink',
     },

--- a/src/components/home/MonthlySummary.vue
+++ b/src/components/home/MonthlySummary.vue
@@ -34,7 +34,7 @@ const formatProfit = (value) => {
 <template>
   <section class="monthly-summary">
     <div class="summary-header">
-      <h3>월별 수입 및 지출 요약</h3>
+      <h3>월별 순수익 요약</h3>
     </div>
 
     <div class="summary-card">

--- a/src/store/home.js
+++ b/src/store/home.js
@@ -58,13 +58,32 @@ export const useHomeStore = defineStore('home', () => {
 
     // 3. 고정 지출 요약
     try {
-      const res = await getFixedDetails(month);
-      if (res.data.length > 0) {
-        state.fixedExpense = {
-          total: res.data[0].total_fixed_expense,
-          items: res.data[0].items,
-        };
-      }
+      const res = await getFixedDetails();
+      const allFixed = res.data;
+      
+      const currentYear = new Date().getFullYear();
+      const currentViewDate = new Date(currentYear, month - 1, 1);
+
+      let total = 0;
+      const validItems = [];
+
+      allFixed.forEach((f) => {
+        const startDate = new Date(f.start_date);
+        // 시작일이 현재 달보다 이전이거나 같을 때만 더하기
+        if (
+          startDate <= currentViewDate ||
+          (startDate.getFullYear() === currentViewDate.getFullYear() &&
+            startDate.getMonth() === currentViewDate.getMonth())
+        ) {
+          total += f.expense || 0;
+          validItems.push(f);
+        }
+      });
+
+      state.fixedExpense = {
+        total,
+        items: validItems,
+      };
     } catch (e) {
       console.error('고정 지출 실패', e);
     }


### PR DESCRIPTION
## 🚀 작업 내용
> 어떤 변경 사항이 있는지 간략하게 설명해 주세요.
라우팅 버그 수정, 홈화면 "이번달 지출 및 수입 요약" 카드 제목  -> "순수익"으로 이름 변경
## 📝 구현한 상세 작업
- [x] 라우팅 버그 수정
- [x] 순수익 이름 변경

## 🔗 관련 이슈
- Resolves: #

## 📸 스크린샷 (선택)

### 🚨 트러블 슈팅(선택)
